### PR TITLE
Improving /random

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 ENV SERVER_PORT=9090
 RUN apk update \
     && apk add --no-cache --virtual .build-dependencies build-base libffi-dev musl-dev python3-dev \
-    && apk add --no-cache --virtual .runtime-dependencies git make python3
+    && apk add --no-cache --virtual .runtime-dependencies curl git jq make python3
 COPY requirements*.txt /app/
 RUN python3 -m ensurepip \
     && pip3 install -U pip \

--- a/api/maps/loader.py
+++ b/api/maps/loader.py
@@ -230,7 +230,7 @@ async def upsert_vertex(xml_entity, session):
             __.unfold(), __.addV(label).property(entity_key, xml_entity.entity_id),
         )
         .property("last_modified", time.time())
-        .property("random", (2 ** 32) * random.random())
+        .property("random", random.random())
     )
     for key, value in dataclasses.asdict(xml_entity).items():
         if value is None or key == entity_key or not hasattr(goblin_entity, key):

--- a/api/maps/views.py
+++ b/api/maps/views.py
@@ -2,7 +2,7 @@ import random
 
 import aiohttp.web
 from aiogremlin.process.graph_traversal import __
-from gremlin_python.process.traversal import Cardinality, P, Scope
+from gremlin_python.process.traversal import Cardinality, Order, P, Scope
 
 from maps.gremlin import textContainsFuzzy, textFuzzy
 
@@ -201,11 +201,12 @@ async def get_random(request):
     session = await request.app["goblin"].session()
     predicates = [P.lte, P.gte]
     for i in range(10):
-        random.shuffle(predicates)
-        has = ["random", predicates[0]((2 ** 32) * random.random())]
+        has = ["random", P.gte(random.random())]
         if vertex_label:
             has.insert(0, vertex_label)
-        traversal = project_vertex(session.g.V().has(*has).limit(100).sample(1))
+        traversal = project_vertex(
+            session.g.V().has(*has).order().by("random", Order.asc).limit(1)
+        )
         result = await traversal.toList()
         if len(result):
             break

--- a/api/maps/views.py
+++ b/api/maps/views.py
@@ -199,7 +199,6 @@ async def get_locality(request):
 async def get_random(request):
     vertex_label = validate_vertex_label(request)
     session = await request.app["goblin"].session()
-    predicates = [P.lte, P.gte]
     for i in range(10):
         has = ["random", P.gte(random.random())]
         if vertex_label:


### PR DESCRIPTION
We need to order the results before limiting, otherwise they're returned in what appears to be insertion order, which decreases the apparent randomness.